### PR TITLE
Faster - Prebuilt Image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,8 @@ on: [push]
 
 jobs:
   build:
+    env:
+      TAG_PREFIX "docker.pkg.github.com/manimaul/android-builder-action/android-sdk"
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
@@ -11,15 +13,18 @@ jobs:
       - name: Docker Auth
         run: docker login docker.pkg.github.com -u ${GITHUB_ACTOR} -p ${{ secrets.GITHUB_TOKEN }}
       - name: Docker Build
-        run: docker build -t docker.pkg.github.com/manimaul/android-builder-action/android:latest $(pwd)
-      - name: Docker Publish
+        run: docker build -t android-sdk $(pwd)/android-sdk
+      - name: Docker Publish Tag
         if: startsWith(github.ref, 'refs/tags')
         run: |
           TAG=$(echo ${{ github.ref }} | sed 's/refs\/tags\/s*//')
           echo "TAG is ${TAG}"
-          TAG_PREFIX="docker.pkg.github.com/manimaul/android-builder-action/android"
-          docker tag ${TAG_PREFIX}:latest ${TAG_PREFIX}:${TAG}
+          docker tag android-sdk ${TAG_PREFIX}:${TAG}
           echo "pushing ${TAG_PREFIX}:${TAG}"
           docker push ${TAG_PREFIX}:${TAG}
-          echo "pushing ${TAG_PREFIX}:latest"
-          docker push ${TAG_PREFIX}:latest
+      - name: Docker Publish Latest
+          if: github.ref == 'refs/heads/master'
+          run: |
+            docker tag android-sdk ${TAG_PREFIX}:latest
+            echo "pushing ${TAG_PREFIX}:latest"
+            docker push ${TAG_PREFIX}:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,8 +23,8 @@ jobs:
           echo "pushing ${TAG_PREFIX}:${TAG}"
           docker push ${TAG_PREFIX}:${TAG}
       - name: Docker Publish Latest
-          if: github.ref == 'refs/heads/master'
-          run: |
-            docker tag android-sdk ${TAG_PREFIX}:latest
-            echo "pushing ${TAG_PREFIX}:latest"
-            docker push ${TAG_PREFIX}:latest
+        if: github.ref == 'refs/heads/master'
+        run: |
+          docker tag android-sdk ${TAG_PREFIX}:latest
+          echo "pushing ${TAG_PREFIX}:latest"
+          docker push ${TAG_PREFIX}:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
     env:
-      TAG_PREFIX "docker.pkg.github.com/manimaul/android-builder-action/android-sdk"
+      TAG_PREFIX: "docker.pkg.github.com/manimaul/android-builder-action/android-sdk"
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,3 @@
-FROM debian:buster
+FROM docker.pkg.github.com/manimaul/android-builder-action/android-sdk:latest
 
-RUN apt update && \
-    apt install -y unzip wget openjdk-11-jre-headless libncurses5
-
-WORKDIR /android-sdk
-
-# https://developer.android.com/studio
-ENV TOOLS "commandlinetools-linux-6200805_latest.zip"
-RUN wget https://dl.google.com/android/repository/${TOOLS}
-RUN unzip ${TOOLS} && rm ${TOOLS}
-ENV ANDROID_SDK_ROOT /android-sdk
-ENV PATH ${ANDROID_SDK_ROOT}/tools/bin:${PATH}
-ENV ANDROID_NDK_HOME /android-sdk/ndk/16.1.4479499 
-
-#https://developer.android.com/studio/command-line/sdkmanager
-RUN yes | sdkmanager --sdk_root=$ANDROID_SDK_ROOT --licenses
-RUN sdkmanager --sdk_root=$ANDROID_SDK_ROOT "platforms;android-29" "ndk-bundle" "ndk;16.1.4479499" "cmake;3.10.2.4988404"
-
-WORKDIR /build
-
+WORKDIR /github/workspace

--- a/README.md
+++ b/README.md
@@ -18,16 +18,18 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v2
       - name: Build with Gradle
-        uses: manimaul/android-builder-action@android-29_ndk-21.0.6113669
+        uses: manimaul/android-builder-action@v1
         with:
           entrypoint: /github/workspace/gradlew
-          args: build
-
+          args: --no-daemon build
 ```
 
-Docker example:
+Build your Android project with just the android-sdk Docker container:
 ```bash
-docker build -t android-builder $(pwd)
-docker run -v /path/to/android/project:/build --entrypoint /build/gradlew android-builder build
+cd /path/to/your/android/project
+docker run -v $(pwd):/build \
+            -w /build \
+            --entrypoint /build/gradlew \
+            docker.pkg.github.com/manimaul/android-builder-action/android-sdk:latest \
+            --no-daemon build
 ```
-

--- a/android-sdk/Dockerfile
+++ b/android-sdk/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:buster
+
+RUN apt update && \
+    apt install -y unzip wget openjdk-11-jre-headless libncurses5
+
+WORKDIR /android-sdk
+
+# https://developer.android.com/studio
+ENV TOOLS "commandlinetools-linux-6200805_latest.zip"
+RUN wget https://dl.google.com/android/repository/${TOOLS}
+RUN unzip ${TOOLS} && rm ${TOOLS}
+ENV ANDROID_SDK_ROOT /android-sdk
+ENV PATH ${ANDROID_SDK_ROOT}/tools/bin:${PATH}
+RUN yes | sdkmanager --sdk_root=$ANDROID_SDK_ROOT --licenses
+RUN sdkmanager --sdk_root=$ANDROID_SDK_ROOT "ndk;21.0.6113669"
+ENV ANDROID_NDK_HOME /android-sdk/ndk/21.0.6113669

--- a/android-sdk/build_publish.sh
+++ b/android-sdk/build_publish.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+pkg=docker.pkg.github.com/manimaul/android-builder-action/android-sdk
+tag=latest
+docker build -t ${pkg}:${tag} ${DIR}
+docker push ${pkg}:${tag}


### PR DESCRIPTION
Pre-build the container image so that each action run does not have to build the container. Github actions do not currently keep docker build cache. So, we'll just pre-build the container image and store in the Github package registry.